### PR TITLE
Xiaomi Aqara Temperature/Humidity Sensor: Change unit for pressure 

### DIFF
--- a/FHEM/72_XiaomiMQTTDevice.pm
+++ b/FHEM/72_XiaomiMQTTDevice.pm
@@ -89,7 +89,7 @@ sub Define() {
             $main::attr{$name}{stateFormat}  = 'temperature °C, humidity %';
         }
         elsif ( $model =~ m/WSDCGQ11LM/) {
-            $main::attr{$name}{stateFormat}  = 'temperature °C, humidity %, pressure kPa';
+            $main::attr{$name}{stateFormat}  = 'temperature °C, humidity %, pressure hPa';
         }
         elsif ($model =~ m/AB3257001NJ/){ # OSRAM Smart+ plug
             $main::attr{$name}{stateFormat} =  "state";


### PR DESCRIPTION
Hi,

I'm not sure if this issue is specific when using zigbee2mqtt and the conversion done by it internally (https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/converters/fromZigbee.js#L610-L613), but the values for atmospheric pressure I get from the Xiaomi Aqara Temperature and Humidity Sensor (model WSDCGQ11LM) are displayed with kPa as unit instead of hPa.
I know that the specifications in the user manual of the device state that the unit for pressure would be kPa but this definitely doesn't fit what I can see in FHEM. 

Please let me know if you would prefer a smarter solution depending on the actual data source (if this is possible, I'm still new to FHEM and MQTT).